### PR TITLE
Drop require relative path

### DIFF
--- a/lib/metadata/ingest/form/version.rb
+++ b/lib/metadata/ingest/form/version.rb
@@ -1,5 +1,3 @@
-require "metadata/ingest/form"
-
 module Metadata
   module Ingest
     class Form


### PR DESCRIPTION
Drop require relative path that was causing errors with bundler.

```
Fetching git://github.com/OregonDigital/metadata-ingest-form.git
  
[!] There was an error while loading `metadata-ingest-form.gemspec`: cannot load such file -- active_model
 
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.
  
 #  from /usr/local/lib/ruby/gems/2.3.0/bundler/gems/metadata-ingest-form-1d36b5a1380f/metadata-ingest-form.gemspec:4
  #  -------------------------------------------
  #  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
  >  require 'metadata/ingest/form/version'
  #  
  #  -------------------------------------------
  
Exited with code exit status 14 
CircleCI received exit code 14 
```

Not exactly sure why this raised up now. Changing OD's Gemfile to point to this branch with the update fixes it and the OD tests pass.